### PR TITLE
Fix incorrect path parameter placeholders in CC Apps API

### DIFF
--- a/cc/api/openapi.yaml
+++ b/cc/api/openapi.yaml
@@ -31,7 +31,7 @@ paths:
       summary: List Accounts
       tags:
       - Accounts
-  /cc/api/account/remove/:id:
+  /cc/api/account/remove/{id}:
     post:
       operationId: removeAccount
       parameters:
@@ -66,7 +66,7 @@ paths:
       summary: List Applications
       tags:
       - Applications
-  /cc/api/app/get/:id:
+  /cc/api/app/get/{id}:
     get:
       operationId: GetApplication
       parameters:
@@ -88,7 +88,7 @@ paths:
       summary: Get Single Application
       tags:
       - Applications
-  /cc/api/app/getAccessProfiles/:id:
+  /cc/api/app/getAccessProfiles/{id}:
     get:
       operationId: GetApplicationAccessProfiles
       parameters:
@@ -126,7 +126,7 @@ paths:
       summary: Create Application
       tags:
       - Applications
-  /cc/api/app/update/:id:
+  /cc/api/app/update/{id}:
     post:
       operationId: UpdateApplication
       parameters:
@@ -153,7 +153,7 @@ paths:
       summary: Update Application
       tags:
       - Applications
-  /cc/api/app/delete/:id:
+  /cc/api/app/delete/{id}:
     post:
       operationId: DeleteApplication
       parameters:


### PR DESCRIPTION
The CC Apps API Open API spec uses an incorrect placeholder format for path parameters which causes requests requiring a path parameter to fail. The generated code is trying to replace `{id}` with the provided app ID, however, the path template has `:id` as the placeholder.

**Spec**
https://github.com/sailpoint-oss/golang-sdk/blob/0354e8d5fecaae25b7204629823db8cced251c55/cc/api/openapi.yaml#L69-L71

**Generated code**
https://github.com/sailpoint-oss/golang-sdk/blob/0354e8d5fecaae25b7204629823db8cced251c55/cc/api_applications.go#L248-L249