### PR TITLE
Fix incorrect path for CC List Apps API

### DIFF
--- a/cc/api/openapi.yaml
+++ b/cc/api/openapi.yaml
@@ -53,7 +53,7 @@ paths:
       summary: Remove Account
       tags:
       - Accounts
-  /cc/api/app:
+  /cc/api/app/list:
     get:
       operationId: listApplications
       responses:


### PR DESCRIPTION
The CC List Applications API is incorrectly calling `/cc/api/app` instead of `/cc/api/app/list` which is returning a 404 error instead of the expected list of applications.