### PR TITLE
Fix 6 bugs in hand-written files, templates, and build scripts

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,8 +9,6 @@ API version: 3.0.0
 package sailpoint
 
 import (
-	"regexp"
-
 	"github.com/hashicorp/go-retryablehttp"
 	beta "github.com/sailpoint-oss/golang-sdk/v2/api_beta"
 	generic "github.com/sailpoint-oss/golang-sdk/v2/api_generic"
@@ -20,17 +18,9 @@ import (
 	v3 "github.com/sailpoint-oss/golang-sdk/v2/api_v3"
 )
 
-var (
-	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
-	xmlCheck  = regexp.MustCompile(`(?i:(?:application|text)/xml)`)
-)
-
 // APIClient manages communication with the IdentityNow V3 API API v3.0.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
-	cfg    *Configuration
-	common service // Reuse a single struct instead of allocating one for each service on the heap.
-
 	// API Services
 
 	V3      *v3.APIClient
@@ -39,16 +29,6 @@ type APIClient struct {
 	V2025   *v2025.APIClient
 	V2026   *v2026.APIClient
 	Generic *generic.APIClient
-	token   string
-}
-
-type service struct {
-	client        *v3.APIClient
-	betaClient    *beta.APIClient
-	v2024Client   *v2024.APIClient
-	v2025Client   *v2025.APIClient
-	v2026Client   *v2026.APIClient
-	genericClient *generic.APIClient
 }
 
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.

--- a/configuration.go
+++ b/configuration.go
@@ -101,12 +101,13 @@ func localConfig() ClientConfiguration {
 		panic(fmt.Errorf("unable to find executable directory: %s \n", err))
 	}
 
-	viper.AddConfigPath(filepath.Dir(executableDir))
-	viper.AddConfigPath(".")
-	viper.SetConfigName("config")
-	viper.SetConfigType("json")
+	v := viper.New()
+	v.AddConfigPath(filepath.Dir(executableDir))
+	v.AddConfigPath(".")
+	v.SetConfigName("config")
+	v.SetConfigType("json")
 
-	if err2 := viper.ReadInConfig(); err != nil {
+	if err2 := v.ReadInConfig(); err2 != nil {
 		if _, ok := err2.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; ignore error if desired
 			// IGNORE they may be using env vars
@@ -116,7 +117,7 @@ func localConfig() ClientConfiguration {
 		}
 	}
 	var simpleConfig ClientConfiguration
-	err3 := viper.Unmarshal(&simpleConfig)
+	err3 := v.Unmarshal(&simpleConfig)
 
 	if err3 != nil {
 		panic(fmt.Errorf("unable to decode Config: %s \n", err3))
@@ -131,11 +132,13 @@ func homeConfig() ClientConfiguration {
 	if err != nil {
 		panic(fmt.Errorf("unable to find home directory: %s \n", err))
 	}
-	viper.AddConfigPath(filepath.Join(home, ".sailpoint"))
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
 
-	if err2 := viper.ReadInConfig(); err != nil {
+	v := viper.New()
+	v.AddConfigPath(filepath.Join(home, ".sailpoint"))
+	v.SetConfigName("config")
+	v.SetConfigType("yaml")
+
+	if err2 := v.ReadInConfig(); err2 != nil {
 		if _, ok := err2.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; ignore error if desired
 			// IGNORE they may be using env vars
@@ -147,7 +150,7 @@ func homeConfig() ClientConfiguration {
 
 	var config OrgConfig
 
-	err3 := viper.Unmarshal(&config)
+	err3 := v.Unmarshal(&config)
 
 	if err3 != nil {
 		panic(fmt.Errorf("unable to decode Config: %s \n", err3))

--- a/sdk-resources/postscript.js
+++ b/sdk-resources/postscript.js
@@ -71,9 +71,7 @@ const createDir = async (srcDir, dirName) => {
 
 const moveFiles = async (srcPath, destPath, filename = null) => {
   try {
-    if (!await fs.stat(destPath)) {
-      await fs.mkdir(destPath, { recursive: true });
-    }
+    await fs.mkdir(destPath, { recursive: true });
 
     if (filename) {
       const filePath = path.join(srcPath, filename);
@@ -175,7 +173,7 @@ const fixFiles = async function (myArray) {
     };
 
     if (file.includes("go.mod") || file.includes("go.sum")) {
-      fs.unlink(file)
+      await fs.unlink(file)
       continue
     }
 
@@ -227,7 +225,7 @@ const fixFiles = async function (myArray) {
       );
 
       if (rawdata !== updatedData) {
-        fs.writeFile(file, updatedData, 'utf8');
+        await fs.writeFile(file, updatedData, 'utf8');
         console.log(`Updated ${file}`);
       } else {
         console.log(`No changes needed in ${file}`);

--- a/sdk-resources/resources/api_test.mustache
+++ b/sdk-resources/resources/api_test.mustache
@@ -21,7 +21,7 @@ import (
 
 func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 
-	configuration := {{goImportAlias}}.NewConfiguration()
+	configuration := {{goImportAlias}}.NewConfiguration({{goImportAlias}}.ClientConfiguration{})
 	apiClient := {{goImportAlias}}.NewAPIClient(configuration)
 
 {{#operations}}


### PR DESCRIPTION
## Summary

Cross-SDK audit identified 6 bugs in the Go SDK across hand-written files, mustache templates, and build scripts. All fixes target the correct layer — hand-written code or templates/build scripts — so generated code will be corrected on next `make build`.

## Bug Fixes

### Critical

**G1: Wrong error variable in `localConfig()` and `homeConfig()` silently swallows config parse errors**
- [`configuration.go` L109, L138](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/configuration.go#L109): `if err2 := viper.ReadInConfig(); err != nil` checked `err` (from the earlier `os.Executable()`/`os.UserHomeDir()` call) instead of `err2`. Since `err` was always `nil` at that point, config file parse errors were silently swallowed.
- **Fix:** Changed `err` to `err2` in both functions.

### Medium

**G2: Global viper instance pollution between `localConfig()` and `homeConfig()`**
- [`configuration.go` L104-L107, L134-L136](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/configuration.go#L104): Both functions called `viper.AddConfigPath()`, `viper.SetConfigName()`, `viper.SetConfigType()` on the global viper instance. Config paths from `localConfig()` leaked into `homeConfig()`, potentially causing the wrong config file to be loaded.
- **Fix:** Each function now creates its own `v := viper.New()` instance.

### Low

**G3: Unused variables, dead code, and unnecessary import in `client.go`**
- [`client.go`](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/client.go): Removed unused `jsonCheck`/`xmlCheck` regexp vars, unused `cfg`/`common`/`token` fields on `APIClient`, the dead `service` struct, and the `"regexp"` import.

**G4: Generated tests don't compile — missing required `ClientConfiguration` argument**
- [`sdk-resources/resources/api_test.mustache` L24](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/api_test.mustache#L24): Template called `NewConfiguration()` with no arguments, but `NewConfiguration` requires a `ClientConfiguration` parameter.
- **Fix:** Changed to `NewConfiguration({{goImportAlias}}.ClientConfiguration{})`.

**G5: Missing `await` on `fs.unlink()` and `fs.writeFile()` in postscript.js**
- [`sdk-resources/postscript.js` L178, L230](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/postscript.js#L178): Fire-and-forget promises could cause race conditions during code generation.
- **Fix:** Added `await` to both calls.

**G6: Broken `fs.stat()` check in `moveFiles()` — `fs.stat()` throws on missing path instead of returning falsy**
- [`sdk-resources/postscript.js` L74](https://github.com/sailpoint-oss/golang-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/postscript.js#L74): `if (!await fs.stat(destPath))` always throws when the path doesn't exist (promises-based `fs.stat` throws `ENOENT`), so the `mkdir` fallback never executes.
- **Fix:** Replaced with `await fs.mkdir(destPath, { recursive: true })` which is a no-op if the directory already exists.

## Verification

- `go build .` passes clean (hand-written code compiles)
- Template fix (G4) will take effect on next `make build` — existing generated test files in `api_*/test/` have the pre-existing bug
- Build script fixes (G5, G6) verified by code inspection

## Test plan

- [ ] Run `go build ./...` after next `make build` to verify generated tests compile
- [ ] Verify config loading works correctly with local `config.json` and home `~/.sailpoint/config.yaml`
- [ ] Run `make build` to verify postscript.js fixes work during code generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)